### PR TITLE
Add test to verify exception rendering

### DIFF
--- a/mountaineer_exceptions/__tests__/controllers/test_exception_controller.py
+++ b/mountaineer_exceptions/__tests__/controllers/test_exception_controller.py
@@ -10,6 +10,7 @@ from mountaineer import (
     Depends,
     RenderBase,
 )
+from mountaineer.cli import handle_build
 
 from mountaineer_exceptions.__tests__.fixtures import get_fixtures_path
 from mountaineer_exceptions.controllers.exception_controller import (
@@ -53,6 +54,9 @@ def app_controller() -> AppController:
 
 @pytest.fixture
 def exception_controller(app_controller: AppController) -> ExceptionController:
+    # Make sure we have the properly built plugin before we try to mount it
+    handle_build(webcontroller="mountaineer_exceptions.cli:app")
+
     app_controller.register(exceptions_plugin)
 
     exception_controller = [

--- a/mountaineer_exceptions/__tests__/controllers/test_exception_controller.py
+++ b/mountaineer_exceptions/__tests__/controllers/test_exception_controller.py
@@ -1,0 +1,108 @@
+from traceback import format_exception
+
+import pytest
+from fastapi.testclient import TestClient
+from mountaineer import (
+    AppController,
+    ConfigBase,
+    ControllerBase,
+    CoreDependencies,
+    Depends,
+    RenderBase,
+)
+
+from mountaineer_exceptions.__tests__.fixtures import get_fixtures_path
+from mountaineer_exceptions.controllers.exception_controller import (
+    ExceptionController,
+)
+from mountaineer_exceptions.plugin import plugin as exceptions_plugin
+
+
+class BrokenRender(RenderBase):
+    message: str
+
+
+class UninheritedConfig(ConfigBase):
+    value: str
+
+
+class BrokenController(ControllerBase):
+    """A controller that has an issue in its render function implementation."""
+
+    url = "/broken"
+    view_path = "broken/page.tsx"
+
+    def render(
+        self,
+        bad_config: UninheritedConfig = Depends(
+            CoreDependencies.get_config_with_type(UninheritedConfig)
+        ),
+    ) -> BrokenRender:
+        return BrokenRender(message=bad_config.value)
+
+
+@pytest.fixture
+def app_controller() -> AppController:
+    return AppController(
+        config=ConfigBase(
+            ENVIRONMENT="development",
+        ),
+        view_root=get_fixtures_path("example_view"),
+    )
+
+
+@pytest.fixture
+def exception_controller(app_controller: AppController) -> ExceptionController:
+    app_controller.register(exceptions_plugin)
+
+    exception_controller = [
+        controller
+        for controller in exceptions_plugin.get_controllers()
+        if isinstance(controller, ExceptionController)
+    ][0]
+
+    return exception_controller
+
+
+@pytest.fixture
+def broken_controller(app_controller: AppController) -> BrokenController:
+    broken_controller = BrokenController()
+    app_controller.register(broken_controller)
+    return broken_controller
+
+
+@pytest.mark.asyncio
+async def test_exception_controller_with_complex_render_error(
+    app_controller: AppController,
+    exception_controller: ExceptionController,
+    broken_controller: BrokenController,
+) -> None:
+    """
+    Test the exception controller by:
+    - Creating a controller that has an issue in its render function
+    - Catching the stack trace of the complex render error
+    - Generating the exception controller HTML using the traceback parser
+
+    """
+
+    # Catch the stack trace of the complex render error
+    exc: Exception | None = None
+    try:
+        # This should trigger the AttributeError
+        test_client = TestClient(app_controller.app)
+        test_client.get("/broken")
+    except Exception as e:
+        exc = e
+
+    assert exc is not None
+    assert isinstance(exc, TypeError)
+
+    html_payload = await exception_controller._definition.route.view_route(  # type: ignore
+        exception=str(exc),
+        stack="".join(format_exception(exc)),
+        parsed_exception=exception_controller.traceback_parser.parse_exception(exc),
+    )
+    html = html_payload.body.decode("utf-8")
+
+    assert "Environment: <!-- -->production" in html
+    assert "fastapi/dependencies/utils.py" in html

--- a/mountaineer_exceptions/__tests__/fixtures/__init__.py
+++ b/mountaineer_exceptions/__tests__/fixtures/__init__.py
@@ -1,0 +1,7 @@
+from importlib.resources import as_file, files
+from pathlib import Path
+
+
+def get_fixtures_path(fixture_name: str) -> Path:
+    with as_file(files(__name__).joinpath(fixture_name)) as path:
+        return Path(path)

--- a/mountaineer_exceptions/__tests__/fixtures/example_view/broken/page.tsx
+++ b/mountaineer_exceptions/__tests__/fixtures/example_view/broken/page.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+const Page = () => {
+    return <div>Broken Page</div>
+}
+
+export default Page

--- a/mountaineer_exceptions/__tests__/fixtures/example_view/package-lock.json
+++ b/mountaineer_exceptions/__tests__/fixtures/example_view/package-lock.json
@@ -1,0 +1,56 @@
+{
+    "name": "views",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "views",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "@types/react": "^19.0.10",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0"
+            },
+            "devDependencies": {}
+        },
+        "node_modules/@types/react": {
+            "version": "19.1.6",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
+            "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+            "dependencies": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
+        }
+    }
+}

--- a/mountaineer_exceptions/__tests__/fixtures/example_view/package.json
+++ b/mountaineer_exceptions/__tests__/fixtures/example_view/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "views",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "lint": "biome lint ."
+    },
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+      "@types/react": "^19.0.10",
+      "react": "^19.1.0",
+      "react-dom": "^19.1.0"
+    },
+    "devDependencies": {
+    }
+  }
+  

--- a/mountaineer_exceptions/controllers/exception_controller.py
+++ b/mountaineer_exceptions/controllers/exception_controller.py
@@ -1,10 +1,12 @@
 from mountaineer.controller import ControllerBase
+from mountaineer.paths import ManagedViewPath
 from mountaineer.render import LinkAttribute, Metadata, RenderBase
 
 from mountaineer_exceptions.controllers.traceback import (
     ExceptionParser,
     ParsedException,
 )
+from mountaineer_exceptions.views import get_core_view_path
 
 
 class ExceptionRender(RenderBase):
@@ -24,7 +26,10 @@ class ExceptionController(ControllerBase):
     """
 
     url = "/_exception"
-    view_path = "core/exception/page.tsx"
+    view_path = (
+        ManagedViewPath.from_view_root(get_core_view_path(""))
+        / "core/exception/page.tsx"
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,11 @@ artifacts = ["mountaineer_exceptions/views/_static", "mountaineer_exceptions/vie
 
 [dependency-groups]
 dev = [
+    "httpx>=0.28.1",
     "mountaineer",
     "pyright>=1.1.400",
     "pytest>=8.3.5",
+    "pytest-asyncio>=1.0.0",
     "ruff>=0.11.9",
     "types-pygments>=2.19.0.20250514",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2025.4.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
+]
+
+[[package]]
 name = "click"
 version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -107,6 +116,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -140,6 +162,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0a/0d4df132bfca1507114198b766f1737d57580c9ad1cf93c1ff673e3387be/httptools-0.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:342dd6946aa6bda4b8f18c734576106b8a31f2fe31492881a9a160ec84ff4bd5", size = 448858 },
     { url = "https://files.pythonhosted.org/packages/1e/6a/787004fdef2cabea27bad1073bf6a33f2437b4dbd3b6fb4a9d71172b1c7c/httptools-0.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b36913ba52008249223042dca46e69967985fb4051951f94357ea681e1f5dc0", size = 452042 },
     { url = "https://files.pythonhosted.org/packages/4d/dc/7decab5c404d1d2cdc1bb330b1bf70e83d6af0396fd4fc76fc60c0d522bf/httptools-0.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:28908df1b9bb8187393d5b5db91435ccc9c8e891657f9cbb42a2541b44c82fc8", size = 87682 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]
@@ -199,6 +236,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "firehot" },
     { name = "inflection" },
+    { name = "mountaineer-exceptions" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -214,6 +252,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.114.1,<1.0.0" },
     { name = "firehot", specifier = ">=0.4.0,<1.0.0" },
     { name = "inflection", specifier = ">=0.5.1,<1.0.0" },
+    { name = "mountaineer-exceptions", specifier = ">=0.1.0" },
     { name = "packaging", specifier = ">=23.2" },
     { name = "pydantic", specifier = ">=2.5.3,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0,<3.0.0" },
@@ -252,9 +291,11 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mountaineer" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "types-pygments" },
 ]
@@ -264,9 +305,11 @@ requires-dist = [{ name = "pygments", specifier = ">=2.19.1" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mountaineer", editable = "../mountaineer" },
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.11.9" },
     { name = "types-pygments", specifier = ">=2.19.0.20250514" },
 ]
@@ -451,6 +494,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add unit tests to verify html rendering behavior. This is the code path that will actually be called by the main mountaineer module in the case of a backend exception.