### PR TITLE
Package generated plugin links

### DIFF
--- a/.github/scripts/verify_plugin_assets.py
+++ b/.github/scripts/verify_plugin_assets.py
@@ -42,8 +42,9 @@ def get_missing_prefixes(wheel_path: Path, asset_prefixes: list[str]) -> list[st
 
     missing_prefixes: list[str] = []
     for raw_prefix in asset_prefixes:
-        prefix = raw_prefix.rstrip("/") + "/"
-        if not any(
+        path = raw_prefix.rstrip("/")
+        prefix = path + "/"
+        if path not in names and not any(
             name.startswith(prefix) and not name.endswith("/") for name in names
         ):
             missing_prefixes.append(raw_prefix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,11 @@ jobs:
 
       - name: Verify packaged plugin assets
         run: |
-          uv run python .github/scripts/verify_plugin_assets.py mountaineer_exceptions/views/.mountaineer/static mountaineer_exceptions/views/.mountaineer/ssr
+          uv run python .github/scripts/verify_plugin_assets.py \
+            mountaineer_exceptions/views/.mountaineer/static \
+            mountaineer_exceptions/views/.mountaineer/ssr \
+            mountaineer_exceptions/views/.mountaineer/api.ts \
+            mountaineer_exceptions/views/core/exception/.mountaineer/links.ts
       
       - name: Store build artifacts
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ build-backend = "hatchling.build"
 artifacts = [
     "mountaineer_exceptions/views/.mountaineer/static",
     "mountaineer_exceptions/views/.mountaineer/ssr",
+    "mountaineer_exceptions/views/.mountaineer/api.ts",
+    "mountaineer_exceptions/views/core/exception/.mountaineer/links.ts",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Installed native-runtime plugins still contribute controller links to a host app’s generated link map. The release wheel shipped precompiled static and SSR assets, but omitted the TypeScript link boundary, so downstream bundlers could not resolve `ExceptionController`.

- Include the generated controller link module and its shared API dependency in wheels.
- Extend packaged-asset verification to accept exact files and enforce both required modules.